### PR TITLE
Fix correct version for pycodestyle

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 5454e6e9a3d02aae38f866eec0d9a7de4ab9f93c10a273fb0340f3d6d09f7514
 
 build:
-  number: 0
+  number: 1
   noarch: python
   entry_points:
     - autopep8 = autopep8:main
@@ -22,7 +22,7 @@ requirements:
     - pip
   run:
     - python >=3.6
-    - pycodestyle >=2.6
+    - pycodestyle >=2.7
     - toml
 
 test:


### PR DESCRIPTION
<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist

Hi all, fix as in https://github.com/hhatto/autopep8/blob/da73f1cfdc50d4d9609d302f9af0189355c0b1c3/setup.py#L13

Cheers!
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
